### PR TITLE
add composer.json configuration for using with wordpress composer architecture (ex: bedrock)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,8 @@
 {
-    "require": {
-        "yahnis-elsts/plugin-update-checker": "^4.11"
-    }
+  "name": "19h47/wordpress-plugin",
+  "description": "Import posts from a Weblex RSS feed.",
+  "type": "wordpress-plugin",
+  "require": {
+      "yahnis-elsts/plugin-update-checker": "^4.11"
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,12 @@
 {
   "name": "19h47/wordpress-plugin",
+  "extra": {
+      "installer-paths": {
+          "web/app/plugins/{$name}/": [
+              "type:wordpress-plugin"
+          ]
+      },
+  },
   "description": "Import posts from a Weblex RSS feed.",
   "type": "wordpress-plugin",
   "version": "1.0.20",

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
   "name": "19h47/wordpress-plugin",
   "description": "Import posts from a Weblex RSS feed.",
   "type": "wordpress-plugin",
+  "version": "1.0.20",
   "require": {
       "yahnis-elsts/plugin-update-checker": "^4.11"
   }


### PR DESCRIPTION
add composer.json configuration for using with wordpress composer architecture (ex: bedrock)